### PR TITLE
feat: add custom error page and centralize layout styling

### DIFF
--- a/routecraft/.vite/deps/_metadata.json
+++ b/routecraft/.vite/deps/_metadata.json
@@ -1,0 +1,8 @@
+{
+  "hash": "0f102cf0",
+  "configHash": "9ffaf2bc",
+  "lockfileHash": "57e67963",
+  "browserHash": "19b1f0d9",
+  "optimized": {},
+  "chunks": {}
+}

--- a/routecraft/.vite/deps/package.json
+++ b/routecraft/.vite/deps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/routecraft/src/App.css
+++ b/routecraft/src/App.css
@@ -40,3 +40,8 @@
 .read-the-docs {
   color: #888;
 }
+/* From RootLayout.module.css */
+.content {
+  margin: 2rem auto;
+  text-align: center;
+}

--- a/routecraft/src/components/RootLayout.module.css
+++ b/routecraft/src/components/RootLayout.module.css
@@ -1,5 +1,0 @@
-/* RootLayout.module.css */
-.content {
-  margin: 2rem auto;
-  text-align: center;
-}

--- a/routecraft/src/components/RootLayout.tsx
+++ b/routecraft/src/components/RootLayout.tsx
@@ -1,13 +1,11 @@
 import MainNavigation from "./MainNavigation";
 import { Outlet } from "react-router-dom";
 
-import classes from "./RootLayout.module.css";
-
 const RootLayout = () => {
   return (
     <>
       <MainNavigation />
-      <main className={classes.content}>
+      <main>
         <Outlet />
       </main>
     </>

--- a/routecraft/src/pages/ErrorPage.tsx
+++ b/routecraft/src/pages/ErrorPage.tsx
@@ -1,0 +1,15 @@
+import MainNavigation from "../components/MainNavigation";
+
+const ErrorPage = () => {
+  return (
+    <>
+      <MainNavigation />
+      <main>
+        <h1>An error occurred</h1>
+        <p>Sorry, we couldn't find the page you're looking for.</p>
+      </main>
+    </>
+  );
+};
+
+export default ErrorPage;

--- a/routecraft/src/router/router.tsx
+++ b/routecraft/src/router/router.tsx
@@ -2,11 +2,13 @@ import { createBrowserRouter } from "react-router-dom";
 import Home from "../pages/HomePage";
 import Products from "../pages/Products";
 import RootLayout from "../components/RootLayout";
+import ErrorPage from "../pages/ErrorPage";
 
 const router = createBrowserRouter([
   {
     path: "/",
     element: <RootLayout />,
+    errorElement: <ErrorPage />,
     children: [
       { path: "/", element: <Home /> },
       { path: "/products", element: <Products /> },


### PR DESCRIPTION
- Added ErrorPage component with navigation and fallback error UI
- Removed RootLayout.module.css and migrated layout styles to global App.css
- Updated RootLayout to use global styles instead of module CSS
- Configured errorElement in router for root path to show custom error page on unmatched routes