### PR TITLE
feat: add dynamic product links using route parameters

### DIFF
--- a/routecraft/src/pages/Products.tsx
+++ b/routecraft/src/pages/Products.tsx
@@ -1,17 +1,27 @@
 /* eslint-disable no-empty-pattern */
 /* eslint-disable @typescript-eslint/no-empty-object-type */
 import React from "react";
+import { Link } from "react-router-dom";
 
 interface ProductsProps {}
+
+const DUMMY_PRODUCTS = [
+  { id: "p1", title: "Product 1" },
+  { id: "p2", title: "Product 2" },
+  { id: "p3", title: "Product 3" },
+];
+
 const Products: React.FC<ProductsProps> = ({}) => {
   return (
     <>
       <h1>Thr products</h1>
       <ul>
-        <li>Product 1</li>
-        <li>Product 2</li>
-        <li>Product 3</li>
-      </ul>
+        {DUMMY_PRODUCTS.map((prod) => (
+          <li key={prod.id}>
+            <Link to={`/products/${prod.id}`}>{prod.title}</Link>
+          </li>
+        ))}
+      </ul> 
     </>
   );
 };


### PR DESCRIPTION
- Replaced hardcoded product links with dynamic generation using map()
- Utilized template literals to build paths with product IDs
- Demonstrated usage of Link (instead of NavLink) for non-active routes
- Simulated backend data with a dummy product array